### PR TITLE
sculptor: make it support dry-struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+Cartograph Changelog
+====================
+
+### master
+
+* Added support for dry-struct
+  ([#3](https://github.com/kyrylo/cartograph/pull/3))

--- a/lib/cartograph/sculptor.rb
+++ b/lib/cartograph/sculptor.rb
@@ -11,11 +11,6 @@ module Cartograph
       map.properties
     end
 
-    def sculpted_object
-      # Fallback initialization of the object we're extracting into
-      @sculpted_object ||= map.mapping.new
-    end
-
     # Set this to pass in an object to extract into. Must
     # @param object must be of the same class as the map#mapping
     def sculpted_object=(object)
@@ -25,15 +20,21 @@ module Cartograph
     end
 
     def sculpt(scope = nil)
-      return nil if @object.nil?
+      return unless @object
 
       scoped_properties = scope ? properties.filter_by_scope(scope) : properties
 
-      scoped_properties.each_with_object(sculpted_object) do |property, mutable|
-        setter_method = "#{property.name}="
-        value = property.value_from(object, scope)
-        mutable.send(setter_method, value)
+      attributes = scoped_properties.each_with_object({}) do |property, h|
+        h[property.name] = property.value_from(object, scope)
       end
+
+      return map.mapping.new(attributes) unless @sculpted_object
+
+      attributes.each do |name, val|
+        @sculpted_object[name] = val
+      end
+
+      @sculpted_object
     end
   end
 end

--- a/spec/lib/cartograph/property_spec.rb
+++ b/spec/lib/cartograph/property_spec.rb
@@ -151,7 +151,7 @@ describe Cartograph::Property do
 
     context 'for a nested property set' do
       it 'returns an object with the properties set on it' do
-        dummy_class = Struct.new(:id, :name)
+        dummy_class = OpenStruct
 
         nested_property = Cartograph::Property.new(:hello) do
           mapping dummy_class
@@ -171,7 +171,7 @@ describe Cartograph::Property do
       end
 
       it 'returns a collection of objects when set to plural' do
-        dummy_class = Struct.new(:id, :name)
+        dummy_class = OpenStruct
 
         nested_property = Cartograph::Property.new(:hello, plural: true) do
           mapping dummy_class

--- a/spec/lib/cartograph/sculptor_spec.rb
+++ b/spec/lib/cartograph/sculptor_spec.rb
@@ -26,25 +26,6 @@ describe Cartograph::Sculptor do
         }.to raise_error(ArgumentError)
       end
     end
-
-    it 'sets the sculpted_object' do
-      hash = {}
-      map = double(Cartograph::Map, mapping: Hash)
-
-      sculptor = Cartograph::Sculptor.new(hash, map)
-      sculptor.sculpted_object = hash
-      expect(sculptor.sculpted_object).to be hash
-    end
-  end
-
-  describe '#sculpted_object' do
-    it 'initializes the mapping class' do
-      hash = {}
-      map = double(Cartograph::Map, mapping: Hash)
-
-      sculptor = Cartograph::Sculptor.new(hash, map)
-      expect(sculptor.sculpted_object).to be_kind_of(Hash)
-    end
   end
 
   describe '#sculpt' do
@@ -80,7 +61,7 @@ describe Cartograph::Sculptor do
         sculptor.sculpted_object = dummy
         sculpted = sculptor.sculpt
 
-        expect(sculpted).to be dummy
+        expect(sculpted).to eq(dummy)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'cartograph'
 
+require 'pry'
+
 Dir['./spec/support/**/*.rb'].each {|f| load f }
 
 RSpec.configure do |config|

--- a/spec/support/dummy_comment.rb
+++ b/spec/support/dummy_comment.rb
@@ -1,2 +1,2 @@
-class DummyComment < Struct.new(:id, :text)
+class DummyComment < OpenStruct
 end

--- a/spec/support/dummy_user.rb
+++ b/spec/support/dummy_user.rb
@@ -1,2 +1,2 @@
-class DummyUser < Struct.new(:id, :name, :comment, :email)
+class DummyUser < OpenStruct
 end


### PR DESCRIPTION
Adds support for http://dry-rb.org/gems/dry-struct/

The problem is that by default dry-struct doesn't allow initialising an empty
structure and even if we use `constructor_type :schema` we can't modify values
later because dry-structs are immutable.